### PR TITLE
throw timezone exception

### DIFF
--- a/src/throttle/exceptions.py
+++ b/src/throttle/exceptions.py
@@ -9,6 +9,9 @@ class RateLimitExceeded(PermissionDenied):
 class ThrottleCoolDownNotDefined(ImproperlyConfigured):
     pass
 
+class TimezoneNotDefined(ImproperlyConfigured):
+    pass
+
 #class ThrottlePreventFunctionNotDefined(ImproperlyConfigured):
 #    pass
 


### PR DESCRIPTION
small PR, although i'm not sure this project will be contain (or maintaining) in DRF section or not.
Makes an exception for the timezone when in the `constants.py` file has a default initial time for the throttle process.

hope this can be reviewed